### PR TITLE
15 fr use version catalogs

### DIFF
--- a/andesite-item/build.gradle.kts
+++ b/andesite-item/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
       }
     }
   }

--- a/andesite-item/build.gradle.kts
+++ b/andesite-item/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
       }
     }
   }

--- a/andesite-komanda/build.gradle.kts
+++ b/andesite-komanda/build.gradle.kts
@@ -30,8 +30,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation("com.github.h0tk3y.betterParse:better-parse:0.4.4")
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
+        implementation(libs.betterParse)
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
       }
     }
   }

--- a/andesite-komanda/build.gradle.kts
+++ b/andesite-komanda/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
     val commonMain by getting {
       dependencies {
         implementation(libs.betterParse)
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-bedrock/andesite-protocol-bedrock-v465/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-bedrock/andesite-protocol-bedrock-v465/build.gradle.kts
@@ -18,7 +18,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
+        implementation(projects.andesiteProtocol.andesiteProtocolBedrock)
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-bedrock/andesite-protocol-bedrock-v465/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-bedrock/andesite-protocol-bedrock-v465/build.gradle.kts
@@ -19,7 +19,6 @@ kotlin {
     val commonMain by getting {
       dependencies {
         implementation(projects.andesiteProtocol.andesiteProtocolBedrock)
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-bedrock/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-bedrock/build.gradle.kts
@@ -18,8 +18,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
-        implementation(projects.andesiteWorld.andesiteWorldCommon)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-bedrock/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-bedrock/build.gradle.kts
@@ -18,8 +18,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
-        implementation(project(":andesite-world:andesite-world-common"))
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        implementation(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-common/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-common/build.gradle.kts
@@ -18,15 +18,15 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation("io.ktor:ktor-network:2.0.3")
-        implementation("com.squareup.okio:okio:3.0.0")
-        implementation("com.github.ajalt.mordant:mordant:2.0.0-beta6")
+        implementation(libs.ktor.network)
+        implementation(libs.okio)
+        implementation(libs.mordant)
       }
     }
 
     val jvmMain by getting {
       dependencies {
-        implementation(kotlin("reflect"))
+        implementation(libs.kt.reflect)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-common/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-common/build.gradle.kts
@@ -18,15 +18,15 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(libs.ktor.network)
-        implementation(libs.okio)
-        implementation(libs.mordant)
+        api(libs.ktor.network)
+        api(libs.okio)
+        api(libs.mordant)
       }
     }
 
     val jvmMain by getting {
       dependencies {
-        implementation(libs.kt.reflect)
+        api(libs.kt.reflect)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-java/andesite-protocol-java-v756/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-java/andesite-protocol-java-v756/build.gradle.kts
@@ -18,10 +18,10 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
-        implementation(projects.andesiteProtocol.andesiteProtocolJava)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(projects.andesiteProtocol.andesiteProtocolJava)
 
-        implementation(projects.andesiteWorld.andesiteWorldCommon)
+        api(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-java/andesite-protocol-java-v756/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-java/andesite-protocol-java-v756/build.gradle.kts
@@ -18,10 +18,10 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
-        implementation(project(":andesite-protocol:andesite-protocol-java"))
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        implementation(projects.andesiteProtocol.andesiteProtocolJava)
 
-        implementation(project(":andesite-world:andesite-world-common"))
+        implementation(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-java/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-java/build.gradle.kts
@@ -18,8 +18,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
-        implementation(projects.andesiteWorld.andesiteWorldCommon)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/andesite-protocol/andesite-protocol-java/build.gradle.kts
+++ b/andesite-protocol/andesite-protocol-java/build.gradle.kts
@@ -18,8 +18,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
-        implementation(project(":andesite-world:andesite-world-common"))
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        implementation(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/andesite-server/andesite-server-bedrock/build.gradle.kts
+++ b/andesite-server/andesite-server-bedrock/build.gradle.kts
@@ -18,9 +18,9 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteServer.andesiteServerCommon)
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
-        implementation(projects.andesiteProtocol.andesiteProtocolBedrock.andesiteProtocolBedrockV465)
+        api(projects.andesiteServer.andesiteServerCommon)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(projects.andesiteProtocol.andesiteProtocolBedrock.andesiteProtocolBedrockV465)
       }
     }
   }

--- a/andesite-server/andesite-server-bedrock/build.gradle.kts
+++ b/andesite-server/andesite-server-bedrock/build.gradle.kts
@@ -18,10 +18,9 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-server:andesite-server-common"))
-
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
-        implementation(project(":andesite-protocol:andesite-protocol-bedrock:andesite-protocol-bedrock-v465"))
+        implementation(projects.andesiteServer.andesiteServerCommon)
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        implementation(projects.andesiteProtocol.andesiteProtocolBedrock.andesiteProtocolBedrockV465)
       }
     }
   }

--- a/andesite-server/andesite-server-common/build.gradle.kts
+++ b/andesite-server/andesite-server-common/build.gradle.kts
@@ -20,16 +20,16 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
-        implementation(projects.andesiteProtocol.andesiteProtocolBedrock)
-        implementation(projects.andesiteProtocol.andesiteProtocolJava)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(projects.andesiteProtocol.andesiteProtocolBedrock)
+        api(projects.andesiteProtocol.andesiteProtocolJava)
 
-        implementation(projects.andesiteWorld.andesiteWorldCommon)
-        implementation(projects.andesiteWorld.andesiteWorldAnvil)
+        api(projects.andesiteWorld.andesiteWorldCommon)
+        api(projects.andesiteWorld.andesiteWorldAnvil)
 
-        implementation(libs.knbt)
+        api(libs.knbt)
 
-        implementation(projects.andesiteKomanda)
+        api(projects.andesiteKomanda)
       }
     }
   }

--- a/andesite-server/andesite-server-common/build.gradle.kts
+++ b/andesite-server/andesite-server-common/build.gradle.kts
@@ -20,16 +20,16 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
-        implementation(project(":andesite-protocol:andesite-protocol-bedrock"))
-        implementation(project(":andesite-protocol:andesite-protocol-java"))
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        implementation(projects.andesiteProtocol.andesiteProtocolBedrock)
+        implementation(projects.andesiteProtocol.andesiteProtocolJava)
 
-        implementation(project(":andesite-world:andesite-world-common"))
-        implementation(project(":andesite-world:andesite-world-anvil"))
+        implementation(projects.andesiteWorld.andesiteWorldCommon)
+        implementation(projects.andesiteWorld.andesiteWorldAnvil)
 
-        implementation(project(":andesite-komanda"))
+        implementation(libs.knbt)
 
-        implementation("net.benwoodworth.knbt:knbt:0.11.1")
+        implementation(projects.andesiteKomanda)
       }
     }
   }

--- a/andesite-server/andesite-server-java/build.gradle.kts
+++ b/andesite-server/andesite-server-java/build.gradle.kts
@@ -20,22 +20,21 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-komanda"))
-        implementation(project(":andesite-server:andesite-server-common"))
+        implementation(projects.andesiteKomanda)
+        implementation(projects.andesiteServer.andesiteServerCommon)
 
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
-        implementation(project(":andesite-protocol:andesite-protocol-java"))
-        implementation(project(":andesite-protocol:andesite-protocol-java:andesite-protocol-java-v756"))
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        implementation(projects.andesiteProtocol.andesiteProtocolJava)
+        implementation(projects.andesiteProtocol.andesiteProtocolJava.andesiteProtocolJavaV756)
 
-        implementation(project(":andesite-world:andesite-world-common"))
-        implementation(project(":andesite-world:andesite-world-slime"))
-        implementation(project(":andesite-world:andesite-world-anvil"))
+        implementation(projects.andesiteWorld.andesiteWorldCommon)
+        implementation(projects.andesiteWorld.andesiteWorldAnvil)
       }
     }
 
     val jvmMain by getting {
       dependencies {
-        implementation(kotlin("reflect"))
+        implementation(libs.kt.reflect)
       }
     }
   }

--- a/andesite-server/andesite-server-java/build.gradle.kts
+++ b/andesite-server/andesite-server-java/build.gradle.kts
@@ -20,21 +20,21 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteKomanda)
-        implementation(projects.andesiteServer.andesiteServerCommon)
+        api(projects.andesiteKomanda)
+        api(projects.andesiteServer.andesiteServerCommon)
 
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
-        implementation(projects.andesiteProtocol.andesiteProtocolJava)
-        implementation(projects.andesiteProtocol.andesiteProtocolJava.andesiteProtocolJavaV756)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(projects.andesiteProtocol.andesiteProtocolJava)
+        api(projects.andesiteProtocol.andesiteProtocolJava.andesiteProtocolJavaV756)
 
-        implementation(projects.andesiteWorld.andesiteWorldCommon)
-        implementation(projects.andesiteWorld.andesiteWorldAnvil)
+        api(projects.andesiteWorld.andesiteWorldCommon)
+        api(projects.andesiteWorld.andesiteWorldAnvil)
       }
     }
 
     val jvmMain by getting {
       dependencies {
-        implementation(libs.kt.reflect)
+        api(libs.kt.reflect)
       }
     }
   }

--- a/andesite-world/andesite-world-anvil/build.gradle.kts
+++ b/andesite-world/andesite-world-anvil/build.gradle.kts
@@ -20,8 +20,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
-        implementation(project(":andesite-world:andesite-world-common"))
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        implementation(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/andesite-world/andesite-world-anvil/build.gradle.kts
+++ b/andesite-world/andesite-world-anvil/build.gradle.kts
@@ -20,8 +20,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
-        implementation(projects.andesiteWorld.andesiteWorldCommon)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/andesite-world/andesite-world-common/build.gradle.kts
+++ b/andesite-world/andesite-world-common/build.gradle.kts
@@ -20,8 +20,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
-        implementation(libs.ktor.network)
+        api(projects.andesiteProtocol.andesiteProtocolCommon)
+        api(libs.ktor.network)
       }
     }
   }

--- a/andesite-world/andesite-world-common/build.gradle.kts
+++ b/andesite-world/andesite-world-common/build.gradle.kts
@@ -20,8 +20,8 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-protocol:andesite-protocol-common"))
-        implementation("io.ktor:ktor-network:2.0.3")
+        implementation(projects.andesiteProtocol.andesiteProtocolCommon)
+        implementation(libs.ktor.network)
       }
     }
   }

--- a/andesite-world/andesite-world-slime/build.gradle.kts
+++ b/andesite-world/andesite-world-slime/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(projects.andesiteWorld.andesiteWorldCommon)
+        api(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/andesite-world/andesite-world-slime/build.gradle.kts
+++ b/andesite-world/andesite-world-slime/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(project(":andesite-world:andesite-world-common"))
+        implementation(projects.andesiteWorld.andesiteWorldCommon)
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,16 +92,16 @@ subprojects {
       val commonMain by getting {
         dependencies {
           afterEvaluate {
-            implementation(libs.ktx.datetime)
-            implementation(libs.ktor.network)
-            implementation(libs.uuid)
-            implementation(libs.knbt)
-            implementation(libs.ktx.atomicfu)
-            implementation(libs.ktx.coroutines.core)
-            implementation(libs.ktx.serialization.json)
+            api(libs.ktx.datetime)
+            api(libs.ktor.network)
+            api(libs.uuid)
+            api(libs.knbt)
+            api(libs.ktx.atomicfu)
+            api(libs.ktx.coroutines.core)
+            api(libs.ktx.serialization.json)
 
             if (project.name != "andesite-shared") {
-              implementation(projects.andesiteShared)
+              api(projects.andesiteShared)
             }
           }
         }
@@ -117,11 +117,11 @@ subprojects {
       val jvmMain by getting {
         dependencies {
           afterEvaluate {
-            implementation(libs.log4j.api)
-            implementation(libs.log4j.core)
-            implementation(libs.log4j.kotlin)
+            api(libs.log4j.api)
+            api(libs.log4j.core)
+            api(libs.log4j.kotlin)
 
-            implementation(libs.ktx.coroutines.jdk8)
+            api(libs.ktx.coroutines.jdk8)
           }
         }
       }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,37 +91,45 @@ subprojects {
 
       val commonMain by getting {
         dependencies {
-          implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.1")
-          implementation("io.ktor:ktor-network:2.0.3")
-          implementation("com.benasher44:uuid:0.3.1")
-          implementation("net.benwoodworth.knbt:knbt:0.11.1")
-          implementation("org.jetbrains.kotlinx:atomicfu:0.17.2")
-          implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
-          implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.0")
+          afterEvaluate {
+            implementation(libs.ktx.datetime)
+            implementation(libs.ktor.network)
+            implementation(libs.uuid)
+            implementation(libs.knbt)
+            implementation(libs.ktx.atomicfu)
+            implementation(libs.ktx.coroutines.core)
+            implementation(libs.ktx.serialization.json)
 
-          if (project.name != "andesite-shared") {
-            implementation(project(":andesite-shared"))
+            if (project.name != "andesite-shared") {
+              implementation(projects.andesiteShared)
+            }
           }
         }
       }
       val commonTest by getting {
         dependencies {
-          implementation(kotlin("test-common"))
+          afterEvaluate {
+            implementation(libs.kt.test.common)
+          }
         }
       }
 
       val jvmMain by getting {
         dependencies {
-          implementation("org.apache.logging.log4j:log4j-api-kotlin:1.1.0")
-          implementation("org.apache.logging.log4j:log4j-api:2.17.2")
-          implementation("org.apache.logging.log4j:log4j-core:2.17.2")
+          afterEvaluate {
+            implementation(libs.log4j.api)
+            implementation(libs.log4j.core)
+            implementation(libs.log4j.kotlin)
 
-          implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.5.2")
+            implementation(libs.ktx.coroutines.jdk8)
+          }
         }
       }
       val jvmTest by getting {
         dependencies {
-          implementation(kotlin("test-junit5"))
+          afterEvaluate {
+            implementation(libs.kt.test.junit)
+          }
         }
       }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,87 @@
+[versions]
+ktx-coroutines = "1.6.4"
+ktx-serialization = "1.4.0-RC"
+ktx-datetime = "0.3.1"
+ktx-atomicfu = "0.17.2"
+kt = "1.7.0"
+ktor = "2.0.3"
+knbt = "0.11.2"
+uuid = "0.3.1"
+mordant = "2.0.0-beta4"
+log4j-core = "2.17.2"
+log4j-kotlin = "1.1.0"
+okio = "3.0.0"
+betterParse = "0.4.4"
+
+# Libraries
+[libraries.kt-reflect]
+module = "org.jetbrains.kotlin:kotlin-reflect"
+version.ref = "kt"
+
+[libraries.kt-test-common]
+module = "org.jetbrains.kotlin:kotlin-test-common"
+version.ref = "kt"
+
+[libraries.kt-test-junit]
+module = "org.jetbrains.kotlin:kotlin-test-junit5"
+version.ref = "kt"
+
+[libraries.kt-test-annotations-common]
+module = "org.jetbrains.kotlin:kotlin-test-annotations-common"
+version.ref = "kt"
+
+[libraries.ktx-atomicfu]
+module = "org.jetbrains.kotlinx:atomicfu"
+version.ref = "ktx-atomicfu"
+
+[libraries.ktx-datetime]
+module = "org.jetbrains.kotlinx:kotlinx-datetime"
+version.ref = "ktx-datetime"
+
+[libraries.ktx-serialization-json]
+module = "org.jetbrains.kotlinx:kotlinx-serialization-json"
+version.ref = "ktx-serialization"
+
+[libraries.ktx-coroutines-core]
+module = "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+version.ref = "ktx-coroutines"
+
+[libraries.ktx-coroutines-jdk8]
+module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8"
+version.ref = "ktx-coroutines"
+
+[libraries.mordant]
+module = "com.github.ajalt.mordant:mordant"
+version.ref = "mordant"
+
+[libraries.log4j-api]
+module = "org.apache.logging.log4j:log4j-api"
+version.ref = "log4j-core"
+
+[libraries.log4j-core]
+module = "org.apache.logging.log4j:log4j-core"
+version.ref = "log4j-core"
+
+[libraries.log4j-kotlin]
+module = "org.apache.logging.log4j:log4j-api-kotlin"
+version.ref = "log4j-kotlin"
+
+[libraries.okio]
+module = "com.squareup.okio:okio"
+version.ref = "okio"
+
+[libraries.ktor-network]
+module = "io.ktor:ktor-network"
+version.ref = "ktor"
+
+[libraries.knbt]
+module = "net.benwoodworth.knbt:knbt"
+version.ref = "knbt"
+
+[libraries.uuid]
+module = "com.benasher44:uuid"
+version.ref = "uuid"
+
+[libraries.betterParse]
+module = "com.github.h0tk3y.betterParse:better-parse"
+version.ref = "betterParse"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,8 @@
 
 rootProject.name = "andesite"
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 include("andesite-shared")
 include("andesite-world:andesite-world-common")
 include("andesite-world:andesite-world-anvil")


### PR DESCRIPTION
- build: use version catalogs and typesafe accessors
- build: use `api` to avoid users to find all the project dependencies
